### PR TITLE
Update footer community links

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -93,8 +93,16 @@ module.exports = {
               to: '/code-of-conduct',
             },
             {
-              label: 'Project Discussion',
+              label: 'UTD Nebula Github',
+              href: 'https://github.com/UTDNebula',
+            },
+            {
+              label: 'Github Project Discussion',
               href: 'https://github.com/UTDNebula/website/discussions',
+            },
+            {
+              label: 'Interest Form',
+              href: 'https://acmutd.typeform.com/to/tlZUaM4V',
             },
           ],
         },


### PR DESCRIPTION
## Overview
Resolves #15 

## What Changed
The community portion of the footer now contains two more links. The first one is a link that leads to an interest form for the project. The second one leads to the main github page for Project Nebula.

![image](https://user-images.githubusercontent.com/29133471/155898153-d92b0db8-2f07-4116-9923-4edc0fbe2467.png)
